### PR TITLE
Feat/#77 output ordering

### DIFF
--- a/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/ApiView.java
+++ b/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/ApiView.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import eu.europeana.api2.v2.model.enums.Profile;
 import eu.europeana.corelib.definitions.edm.beans.ApiBean;
 import eu.europeana.corelib.utils.DateUtils;
+import org.codehaus.jackson.annotate.JsonPropertyOrder;
 
 import java.util.Date;
 import java.util.List;
@@ -13,6 +14,7 @@ import java.util.Map;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 
 @JsonInclude(NON_EMPTY)
+@JsonPropertyOrder(alphabetic=true)
 public class ApiView extends BriefView implements ApiBean {
 
     private String[] edmConceptTerm;

--- a/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/BriefView.java
+++ b/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/BriefView.java
@@ -36,8 +36,10 @@ import eu.europeana.corelib.definitions.solr.DocType;
 import eu.europeana.corelib.solr.bean.impl.IdBeanImpl;
 import eu.europeana.corelib.web.service.EuropeanaUrlService;
 import eu.europeana.corelib.web.service.impl.EuropeanaUrlServiceImpl;
+import org.codehaus.jackson.annotate.JsonPropertyOrder;
 
 @JsonInclude(NON_EMPTY)
+@JsonPropertyOrder(alphabetic=true)
 public class BriefView extends IdBeanImpl implements BriefBean {
 
     protected EuropeanaUrlService urlService;

--- a/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/FullDoc.java
+++ b/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/FullDoc.java
@@ -39,7 +39,9 @@ import eu.europeana.corelib.definitions.edm.entity.Place;
 import eu.europeana.corelib.definitions.edm.entity.Proxy;
 import eu.europeana.corelib.definitions.edm.entity.Timespan;
 import eu.europeana.corelib.web.service.impl.EuropeanaUrlServiceImpl;
+import org.codehaus.jackson.annotate.JsonPropertyOrder;
 
+@JsonPropertyOrder(alphabetic=true)
 public class FullDoc {
 
 	private Map<String, Object> map;

--- a/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/FullView.java
+++ b/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/FullView.java
@@ -25,6 +25,7 @@ import eu.europeana.corelib.web.service.EuropeanaUrlService;
 import eu.europeana.corelib.web.service.impl.EuropeanaUrlServiceImpl;
 import org.apache.commons.lang.StringUtils;
 import org.bson.types.ObjectId;
+import org.codehaus.jackson.annotate.JsonPropertyOrder;
 
 import java.util.Date;
 import java.util.List;
@@ -32,6 +33,7 @@ import java.util.List;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 
 @JsonInclude(NON_EMPTY)
+@JsonPropertyOrder(alphabetic=true)
 public class FullView implements FullBean {
 
   private FullBean bean;

--- a/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/RichView.java
+++ b/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/RichView.java
@@ -8,7 +8,9 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 
 import eu.europeana.corelib.definitions.edm.beans.RichBean;
+import org.codehaus.jackson.annotate.JsonPropertyOrder;
 
+@JsonPropertyOrder(alphabetic=true)
 public class RichView extends ApiView implements RichBean {
 
     private String[] isShownBy;

--- a/api2-war/src/main/java/eu/europeana/api2/utils/JsonUtils.java
+++ b/api2-war/src/main/java/eu/europeana/api2/utils/JsonUtils.java
@@ -25,6 +25,7 @@ import org.apache.log4j.Logger;
 import org.springframework.web.servlet.ModelAndView;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class JsonUtils {
@@ -37,7 +38,7 @@ public class JsonUtils {
 
     public static ModelAndView toJson(String json, String callback) {
         String resultPage = "json";
-        Map<String, Object> model = new HashMap<>();
+        Map<String, Object> model = new LinkedHashMap<>();
         model.put("json", json);
         if (StringUtils.isNotBlank(callback)) {
             resultPage = "jsonp";
@@ -56,7 +57,7 @@ public class JsonUtils {
         }
         // TODO report error...
         String resultPage = "json";
-        Map<String, Object> model = new HashMap<>();
+        Map<String, Object> model = new LinkedHashMap<>();
         if (StringUtils.isNotBlank(callback)) {
             resultPage = "jsonp";
             model.put("callback", callback);


### PR DESCRIPTION
Replaced the HashMaps in JsonUtils.java with LinkedHashMaps in an attempt to stabilise the order of JSON elements in the API Object output (see https://europeanadev.assembla.com/spaces/europeana-apis/tickets/realtime_cardwall?ticket=77)

Also added _@JsonPropertyOrder(alphabetic=true)_ annotations to the View classes in eu.europeana.api2.v2.model.json.view, though it's doubtful if this makes any difference. It won't do any harm either, though. 