### PR TITLE
EA-1306 fix url generation

### DIFF
--- a/api2-model/src/main/java/eu/europeana/api2/model/utils/Api2UrlService.java
+++ b/api2-model/src/main/java/eu/europeana/api2/model/utils/Api2UrlService.java
@@ -1,0 +1,159 @@
+package eu.europeana.api2.model.utils;
+
+import eu.europeana.corelib.definitions.ApplicationContextContainer;
+import eu.europeana.corelib.definitions.EuropeanaStaticUrl;
+import eu.europeana.corelib.definitions.solr.DocType;
+import eu.europeana.corelib.web.service.impl.EuropeanaUrlBuilder;
+import eu.europeana.corelib.web.utils.UrlBuilder;
+import org.apache.commons.lang.StringUtils;
+
+
+/**
+ * For generating often used links. Note that if an alternative portal.baseurl or api2.baseurl is defined in the
+ * europeana.properties file then those base urls are used
+ * @author Patrick Ehlert
+ * Created on 10-10-2018
+ */
+
+public class Api2UrlService {
+
+    private String portalBaseUrl;
+    private String api2BaseUrl;
+
+    /**
+     * Provides quick access to this class
+     * @return instance of the Api2UrlBuilder bean
+     */
+    public static Api2UrlService getBeanInstance() {
+        return ApplicationContextContainer.getBean(Api2UrlService.class);
+    }
+
+    public Api2UrlService(String portalBaseUrl, String api2BaseUrl) {
+        this.portalBaseUrl = portalBaseUrl;
+        this.api2BaseUrl = api2BaseUrl;
+    }
+
+    /**
+     * @return either the default or alternative configured base url for the main Europeana website (a.k.a. Portal)
+     */
+    public String getPortalBaseUrl() {
+        if (StringUtils.isEmpty(portalBaseUrl)) {
+            return EuropeanaStaticUrl.EUROPEANA_PORTAL_URL;
+        }
+        return portalBaseUrl;
+    }
+
+    /**
+     * @return either the default or alternative configured base url for the API
+     */
+    public String getApi2BaseUrl() {
+        if (StringUtils.isEmpty(api2BaseUrl)) {
+            return "https://api.europeana.eu";
+        }
+        return api2BaseUrl;
+    }
+
+    /**
+     * Generates an url to retrieve a record from the Europeana website
+     * @param collectionId
+     * @param itemId
+     * @return url as String
+     */
+    public String getRecordPortalUrl(String collectionId, String itemId) {
+        return getRecordPortalUrl("/" + collectionId + "/" +itemId);
+    }
+
+    /**
+     * Generates an url to retrieve a record from the Europeana website
+     * @param europeanaId
+     * @return url as String
+     */
+    public String getRecordPortalUrl(String europeanaId) {
+        UrlBuilder url = new UrlBuilder(this.getPortalBaseUrl())
+                .addPath("portal", "record")
+                .addPage(europeanaId + ".html");
+        return url.toString();
+    }
+
+    /**
+     * Generates an old-style url to retrieve a record from the Europeana website
+     * Note that the EuropeanaId database still contains a lot of these urls as 'oldId'
+     * @param europeanaId
+     * @return url as String
+     */
+    public String getRecordResolveUrl(String europeanaId) {
+        UrlBuilder url = new UrlBuilder(this.getPortalBaseUrl())
+                .addPath("resolve", "record")
+                .addPage(europeanaId);
+        return url.toString();
+    }
+
+    /**
+     * Generates an url to retrieve record JSON data from the Record API
+     * @param collectionId
+     * @param itemId
+     * @param wskey
+     * @return url as String
+     */
+    public String getRecordApi2Url(String collectionId, String itemId, String wskey) {
+        return getRecordApi2Url("/" + collectionId + "/" +itemId, wskey);
+    }
+
+    /**
+     * Generates an url to retrieve record JSON data from the Record API
+     * @param europeanaId
+     * @param wskey
+     * @return url as String
+     */
+    public String getRecordApi2Url(String europeanaId, String wskey) {
+        UrlBuilder url = new UrlBuilder(getApi2BaseUrl())
+                .addPath("api", "v2", "record")
+                .addPage(europeanaId + ".json")
+                .addParam("wskey", wskey);
+        return url.toString();
+    }
+
+    /**
+     * Generates an url to retrieve a thumbnail with default size from the Europeana Thumbnail Storage
+     * The url is processed eventually by the ThumbnailController in the API2 project.
+     * @param uri uri of original thumbnail. A null value can be provided but will result in a not-working thumbnail-url
+     *            so for proper working an uri is required.
+     * @param type defaults to IMAGE (optional)
+     * @return url as String
+     */
+    public String getThumbnailUrl(String uri, DocType type) {
+        return getThumbnailUrl(uri, null, type);
+    }
+
+    /**
+     * Generates an url to retrieve a thumbnail from the Europeana Thumbnail Storage
+     * The url is process eventually by the ThumbnailController in the API2 project.
+     * @param uri uri of original thumbnail. A null value can be provided but will result in a not-working thumbnail-url
+     *            so for proper working an uri is required.
+     * @param size either w200 or w400, other values are ignored (optional)
+     * @param type defaults to IMAGE (optional)
+     * @return url as String
+     */
+    public String getThumbnailUrl(String uri, String size, DocType type) {
+        UrlBuilder url = EuropeanaUrlBuilder.getThumbnailUrl(uri, size, type);
+        String newBaseUrl = this.getApi2BaseUrl();
+        url.setProtocol(newBaseUrl);
+        url.setDomain(newBaseUrl);
+        return url.toString();
+    }
+
+
+    public String getRedirectUrl(String wskey, String isShownAtUri, String provider, String europeanaId, String profile) {
+        UrlBuilder url = new UrlBuilder(this.getApi2BaseUrl())
+                .addPath("api", String.valueOf(wskey), "redirect").disableTrailingSlash()
+                .addParam("shownAt", isShownAtUri)
+                // Note that provider and id are not required paramaters for the RedirectController, but sent along for
+                // logging purposes.
+                .addParam("provider", provider)
+                .addParam("id", this.getRecordResolveUrl(europeanaId))
+                // Not sure the profile parameter still serves any purpose, can probably be removed
+                .addParam("profile", profile);
+        return url.toString();
+    }
+
+}

--- a/api2-model/src/main/java/eu/europeana/api2/model/utils/LinkUtils.java
+++ b/api2-model/src/main/java/eu/europeana/api2/model/utils/LinkUtils.java
@@ -17,18 +17,19 @@
 
 package eu.europeana.api2.model.utils;
 
-import eu.europeana.corelib.web.utils.UrlBuilder;
-
 /**
- * @deprecated 2018-01-09 old MyEuropeana functionality
+ * @deprecated 2018-01-09 Seems like we don't use campaigncodes anymore, even though they are still present in some
+ * links (e.g. search results item.guid)
  */
 @Deprecated
 public class LinkUtils {
 
-	public static String addCampaignCodes(UrlBuilder url, String wskey) {
-		url.addParam("utm_source", "api");
-		url.addParam("utm_medium", "api");
-		url.addParam("utm_campaign", wskey);
-		return url.toString();
+	public static String addCampaignCodes(String url, String wskey) {
+		StringBuilder s = new StringBuilder(url);
+		s.append("?utm_source=api");
+		s.append("&utm_medium=api");
+        s.append("&utm_campaign=");
+		s.append(wskey);
+		return s.toString();
 	}
 }

--- a/api2-model/src/main/java/eu/europeana/api2/model/xml/srw/SrwResponse.java
+++ b/api2-model/src/main/java/eu/europeana/api2/model/xml/srw/SrwResponse.java
@@ -22,7 +22,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 import eu.europeana.api2.v2.model.xml.srw.EchoedSearchRetrieveRequest;
 import eu.europeana.api2.v2.model.xml.srw.Records;
-import eu.europeana.corelib.web.service.EuropeanaUrlService;
+import eu.europeana.corelib.definitions.EuropeanaStaticUrl;
 
 @XmlRootElement(name = "searchRetrieveResponse")
 public class SrwResponse {
@@ -31,8 +31,8 @@ public class SrwResponse {
 	public static final String NS_DIAG = "http://www.loc.gov/zing/srw/diagnostic/";
 	public static final String NS_XCQL = "http://www.loc.gov/zing/cql/xcql/";
 	public static final String NS_MODS = "http://www.loc.gov/mods/v3";
-	public static final String NS_EUROPEANA = EuropeanaUrlService.URL_EUROPEANA;
-	public static final String NS_ENRICHMENT = EuropeanaUrlService.URL_EUROPEANA + "/schemas/ese/enrichment/";
+	public static final String NS_EUROPEANA = EuropeanaStaticUrl.EUROPEANA_NAMESPACE_URL;
+	public static final String NS_ENRICHMENT = EuropeanaStaticUrl.EUROPEANA_NAMESPACE_URL + "/schemas/ese/enrichment/";
 	public static final String NS_DCTERMS = "http://purl.org/dc/terms/";
 	public static final String NS_DC = "http://purl.org/dc/elements/1.1/";
 	public static final String NS_DCX = "http://purl.org/dc/elements/1.1/";

--- a/api2-model/src/main/java/eu/europeana/api2/v2/model/json/abstracts/UserObject.java
+++ b/api2-model/src/main/java/eu/europeana/api2/v2/model/json/abstracts/UserObject.java
@@ -18,8 +18,8 @@
 package eu.europeana.api2.v2.model.json.abstracts;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import eu.europeana.api2.model.utils.Api2UrlService;
 import eu.europeana.corelib.definitions.solr.DocType;
-import eu.europeana.corelib.web.service.impl.EuropeanaUrlServiceImpl;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.Date;
@@ -72,7 +72,7 @@ public abstract class UserObject {
 
     public String getEdmPreview() {
         if (StringUtils.isNotBlank(edmPreview)) {
-            return EuropeanaUrlServiceImpl.getBeanInstance().getThumbnailUrl(edmPreview, type).toString();
+            return Api2UrlService.getBeanInstance().getThumbnailUrl(edmPreview, type);
         }
         return null;
     }

--- a/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/BriefView.java
+++ b/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/BriefView.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import eu.europeana.api2.model.utils.Api2UrlService;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 
@@ -34,15 +35,13 @@ import eu.europeana.api2.v2.model.enums.Profile;
 import eu.europeana.corelib.definitions.edm.beans.BriefBean;
 import eu.europeana.corelib.definitions.solr.DocType;
 import eu.europeana.corelib.solr.bean.impl.IdBeanImpl;
-import eu.europeana.corelib.web.service.EuropeanaUrlService;
-import eu.europeana.corelib.web.service.impl.EuropeanaUrlServiceImpl;
 import org.codehaus.jackson.annotate.JsonPropertyOrder;
 
 @JsonInclude(NON_EMPTY)
 @JsonPropertyOrder(alphabetic=true)
 public class BriefView extends IdBeanImpl implements BriefBean {
 
-    protected EuropeanaUrlService urlService;
+    protected Api2UrlService urlService;
 
     protected String profile;
     protected String wskey;
@@ -53,7 +52,7 @@ public class BriefView extends IdBeanImpl implements BriefBean {
         this.bean = bean;
         this.profile = profile;
         this.wskey = wskey;
-        urlService = EuropeanaUrlServiceImpl.getBeanInstance();
+        urlService = Api2UrlService.getBeanInstance();
     }
 
     public String getProfile() {
@@ -289,7 +288,7 @@ public class BriefView extends IdBeanImpl implements BriefBean {
             if (bean.getEdmObject() != null) {
                 for (String object : bean.getEdmObject()) {
                     String tn = StringUtils.defaultIfBlank(object, "");
-                    final String url = urlService.getThumbnailUrl(tn, getType()).toString();
+                    final String url = urlService.getThumbnailUrl(tn, getType());
                     if (StringUtils.isNotBlank(url)) {
                         thumbs.add(url.trim());
                     }
@@ -301,13 +300,13 @@ public class BriefView extends IdBeanImpl implements BriefBean {
     }
 
     public String getLink() {
-        return urlService.getApi2RecordJson(wskey, getId()).toString();
+        return urlService.getRecordApi2Url(getId(), wskey);
     }
 
     /* January 2018: method potentially deprecated!?
        GUID is a field that was introduced years ago, but there isn't any documentation on it. It's unclear if it's still used */
     public String getGuid() {
-        return LinkUtils.addCampaignCodes(urlService.getPortalRecord(getId()), wskey);
+        return LinkUtils.addCampaignCodes(urlService.getRecordPortalUrl(getId()), wskey);
     }
 
     @Override
@@ -339,10 +338,7 @@ public class BriefView extends IdBeanImpl implements BriefBean {
             if (StringUtils.isBlank(bean.getEdmIsShownAt()[0])) {
                 continue;
             }
-            String isShownAtLink = urlService.getApi2Redirect(
-                    wskey, isShownAt, provider, bean.getId(), profile)
-                    .toString();
-
+            String isShownAtLink = urlService.getRedirectUrl(wskey, isShownAt, provider, bean.getId(), profile);
             isShownAtLinks.add(isShownAtLink);
         }
         return isShownAtLinks.toArray(new String[isShownAtLinks.size()]);

--- a/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/FullDoc.java
+++ b/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/FullDoc.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import javax.xml.bind.annotation.XmlElement;
 
+import eu.europeana.api2.model.utils.Api2UrlService;
 import org.apache.commons.lang.ArrayUtils;
 
 import eu.europeana.api2.model.xml.srw.SrwResponse;
@@ -38,9 +39,11 @@ import eu.europeana.corelib.definitions.edm.entity.EuropeanaAggregation;
 import eu.europeana.corelib.definitions.edm.entity.Place;
 import eu.europeana.corelib.definitions.edm.entity.Proxy;
 import eu.europeana.corelib.definitions.edm.entity.Timespan;
-import eu.europeana.corelib.web.service.impl.EuropeanaUrlServiceImpl;
 import org.codehaus.jackson.annotate.JsonPropertyOrder;
 
+/**
+ * This class is only used in old SRW responses
+ */
 @JsonPropertyOrder(alphabetic=true)
 public class FullDoc {
 
@@ -126,7 +129,7 @@ public class FullDoc {
 	private String[] enrichmentAgentLabel;
 
 	public FullDoc(FullBean bean) {
-		id = EuropeanaUrlServiceImpl.getBeanInstance().getPortalResolve(bean.getAbout());
+		id = Api2UrlService.getBeanInstance().getRecordResolveUrl(bean.getAbout());
 		europeanaCollectionName = bean.getEuropeanaCollectionName();
 		if (bean.getType() != null)
 			type = bean.getType().toString();

--- a/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/FullView.java
+++ b/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/FullView.java
@@ -180,6 +180,8 @@ public class FullView implements FullBean {
   public EuropeanaAggregation getEuropeanaAggregation() {
     EuropeanaAggregation europeanaAggregation = bean.getEuropeanaAggregation();
     europeanaAggregation.setId(null);
+
+    // set proper edmPreview
     String edmPreview = "";
     if (this.getAggregations().get(0).getEdmObject() != null) {
       String url = this.getAggregations().get(0).getEdmObject();
@@ -188,6 +190,9 @@ public class FullView implements FullBean {
       }
     }
     europeanaAggregation.setEdmPreview(edmPreview);
+
+    // set proper landingPage
+    europeanaAggregation.setEdmLandingPage(urlService.getRecordPortalUrl(getAbout()));
     return europeanaAggregation;
   }
 

--- a/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/FullView.java
+++ b/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/FullView.java
@@ -16,13 +16,12 @@ package eu.europeana.api2.v2.model.json.view;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import eu.europeana.api2.model.utils.Api2UrlService;
 import eu.europeana.corelib.definitions.edm.beans.BriefBean;
 import eu.europeana.corelib.definitions.edm.beans.FullBean;
 import eu.europeana.corelib.definitions.edm.entity.*;
 import eu.europeana.corelib.definitions.solr.DocType;
 import eu.europeana.corelib.utils.DateUtils;
-import eu.europeana.corelib.web.service.EuropeanaUrlService;
-import eu.europeana.corelib.web.service.impl.EuropeanaUrlServiceImpl;
 import org.apache.commons.lang.StringUtils;
 import org.bson.types.ObjectId;
 import org.codehaus.jackson.annotate.JsonPropertyOrder;
@@ -39,7 +38,7 @@ public class FullView implements FullBean {
   private FullBean bean;
   private String profile;
   private String apiKey;
-  private EuropeanaUrlService europeanaUrlService;
+  private Api2UrlService urlService;
   private Date timestampCreated;
   private Date timestampUpdated;
   private boolean urlified = false;
@@ -48,7 +47,7 @@ public class FullView implements FullBean {
     this.bean = bean;
     this.profile = profile;
     this.apiKey = apiKey;
-    europeanaUrlService = EuropeanaUrlServiceImpl.getBeanInstance();
+    this.urlService = Api2UrlService.getBeanInstance();
     extractTimestampCreated();
     extractTimestampUpdated();
   }
@@ -138,8 +137,7 @@ public class FullView implements FullBean {
       String isShownAt = item.getEdmIsShownAt();
       if (!urlified && isShownAt != null) {
         String provider = item.getEdmProvider().values().iterator().next().get(0);
-        String isShownAtLink = europeanaUrlService
-            .getApi2Redirect(apiKey, isShownAt, provider, bean.getAbout(), profile).toString();
+        String isShownAtLink = urlService.getRedirectUrl(apiKey, isShownAt, provider, bean.getAbout(), profile);
         item.setEdmIsShownAt(isShownAtLink);
         urlified = true; // do this ONLY ONCE
       }
@@ -186,7 +184,7 @@ public class FullView implements FullBean {
     if (this.getAggregations().get(0).getEdmObject() != null) {
       String url = this.getAggregations().get(0).getEdmObject();
       if (StringUtils.isNotBlank(url)) {
-        edmPreview = europeanaUrlService.getThumbnailUrl(url, getType()).toString();
+        edmPreview = urlService.getThumbnailUrl(url, getType());
       }
     }
     europeanaAggregation.setEdmPreview(edmPreview);

--- a/api2-model/src/main/java/eu/europeana/api2/v2/model/xml/definitions/Namespaces.java
+++ b/api2-model/src/main/java/eu/europeana/api2/v2/model/xml/definitions/Namespaces.java
@@ -17,7 +17,7 @@
 
 package eu.europeana.api2.v2.model.xml.definitions;
 
-import eu.europeana.corelib.web.service.EuropeanaUrlService;
+import eu.europeana.corelib.definitions.EuropeanaStaticUrl;
 
 public class Namespaces {
 
@@ -27,7 +27,7 @@ public class Namespaces {
 	public static final String NS_DCTERM = "http://purl.org/dc/terms/";
 	public static final String NS_FIELDTRIP = "http://www.fieldtripper.com/fieldtrip_rss";
 	public static final String NS_GEORSS = "http://www.georss.org/georss";
-	public static final String NS_EUROPEANA = EuropeanaUrlService.URL_EUROPEANA;
-	public static final String NS_ENRICHMENT = EuropeanaUrlService.URL_EUROPEANA + "/schemas/ese/enrichment/";
+	public static final String NS_EUROPEANA = EuropeanaStaticUrl.EUROPEANA_NAMESPACE_URL;
+	public static final String NS_ENRICHMENT = EuropeanaStaticUrl.EUROPEANA_NAMESPACE_URL + "/schemas/ese/enrichment/";
 
 }

--- a/api2-model/src/main/java/eu/europeana/api2/v2/model/xml/rss/Channel.java
+++ b/api2-model/src/main/java/eu/europeana/api2/v2/model/xml/rss/Channel.java
@@ -22,13 +22,13 @@ import java.util.List;
 
 import javax.xml.bind.annotation.XmlElement;
 
+import eu.europeana.corelib.definitions.EuropeanaStaticUrl;
 import org.apache.commons.lang.StringUtils;
 
 import eu.europeana.api2.v2.model.xml.definitions.Namespaces;
 import eu.europeana.api2.v2.model.xml.rss.atom.AtomLink;
 import eu.europeana.api2.v2.model.xml.rss.opensearch.Query;
 import eu.europeana.api2.v2.model.xml.rss.opensearch.Statistic;
-import eu.europeana.corelib.web.service.EuropeanaUrlService;
 
 /**
  * @author Willem-Jan Boogerd <www.eledge.net/contact>
@@ -42,7 +42,7 @@ public class Channel {
 	private String title = "Europeana Open Search";
 
 	@XmlElement
-	private String link = EuropeanaUrlService.URL_EUROPEANA;
+	private String link = EuropeanaStaticUrl.EUROPEANA_PORTAL_URL;
 
 	@XmlElement
 	private String description = "Europeana Open Search results";

--- a/api2-model/src/main/java/eu/europeana/api2/v2/model/xml/rss/ChannelImage.java
+++ b/api2-model/src/main/java/eu/europeana/api2/v2/model/xml/rss/ChannelImage.java
@@ -19,7 +19,7 @@ package eu.europeana.api2.v2.model.xml.rss;
 
 import javax.xml.bind.annotation.XmlElement;
 
-import eu.europeana.corelib.web.service.EuropeanaUrlService;
+import eu.europeana.corelib.definitions.EuropeanaStaticUrl;
 
 @SuppressWarnings("unused")
 public class ChannelImage {
@@ -28,12 +28,9 @@ public class ChannelImage {
 	private String title = "Europeana Open Search";
 
 	@XmlElement(name = "link")
-	private String link = EuropeanaUrlService.URL_EUROPEANA;
+	private String link = EuropeanaStaticUrl.EUROPEANA_PORTAL_URL;
 
 	@XmlElement(name = "url")
-	private String url = EuropeanaUrlService.URL_EUROPEANA + "/portal/sp/img/europeana-logo-en.png";
+	private String url = "https://style.europeana.eu/images/europeana-logo-default.png";
 
-//	private int width = 206;
-//
-//	private int height = 123;
 }

--- a/api2-model/src/main/java/eu/europeana/api2/v2/model/xml/rss/package-info.java
+++ b/api2-model/src/main/java/eu/europeana/api2/v2/model/xml/rss/package-info.java
@@ -22,10 +22,10 @@
 		@XmlNs(namespaceURI = "http://purl.org/dc/terms/", prefix = "dcterms"),
 		@XmlNs(namespaceURI = "http://www.fieldtripper.com/fieldtrip_rss", prefix = "fieldtrip"),
 		@XmlNs(namespaceURI = "http://www.georss.org/georss", prefix = "georss"),
-		@XmlNs(namespaceURI = EuropeanaUrlService.URL_EUROPEANA, prefix = "europeana"),
-		@XmlNs(namespaceURI = EuropeanaUrlService.URL_EUROPEANA+"/schemas/ese/enrichment/", prefix = "enrichment") }, elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+		@XmlNs(namespaceURI = EuropeanaStaticUrl.EUROPEANA_NAMESPACE_URL, prefix = "europeana"),
+		@XmlNs(namespaceURI = EuropeanaStaticUrl.EUROPEANA_NAMESPACE_URL +"/schemas/ese/enrichment/", prefix = "enrichment") }, elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package eu.europeana.api2.v2.model.xml.rss;
 
 import javax.xml.bind.annotation.XmlNs;
 import javax.xml.bind.annotation.XmlSchema;
-import eu.europeana.corelib.web.service.EuropeanaUrlService;
+import eu.europeana.corelib.definitions.EuropeanaStaticUrl;

--- a/api2-war/src/main/java/eu/europeana/api2/config/AppConfig.java
+++ b/api2-war/src/main/java/eu/europeana/api2/config/AppConfig.java
@@ -1,5 +1,6 @@
 package eu.europeana.api2.config;
 
+import eu.europeana.api2.model.utils.Api2UrlService;
 import eu.europeana.api2.v2.utils.ApiKeyUtils;
 import eu.europeana.features.ObjectStorageClient;
 import eu.europeana.features.S3ObjectStorageClient;
@@ -47,6 +48,11 @@ public class AppConfig {
     private static final String QUERY_FILTER_STALE_SESSION =
                     " AND state in ('idle', 'idle in transaction', 'idle in transaction (aborted)', 'disabled')" +
                     " AND current_timestamp - state_change > interval '5 minutes'";
+
+    @Value("${portal.baseUrl:}")
+    private String portalBaseUrl;
+    @Value("${api2.baseUrl:}")
+    private String api2BaseUrl;
 
     @Value("${s3.key}")
     private String key;
@@ -217,6 +223,19 @@ public class AppConfig {
         return new ApiKeyUtils();
     }
 
+
+    /**
+     * Setup service for generating API and Portal urls
+     * @return
+     */
+    @Bean
+    public Api2UrlService api2UrlService() {
+        Api2UrlService urlService = new Api2UrlService(portalBaseUrl, api2BaseUrl);
+        LogManager.getLogger(Api2UrlService.class).info("Portal base url = {}", urlService.getPortalBaseUrl());
+        LogManager.getLogger(Api2UrlService.class).info("API2 base url = {}", urlService.getApi2BaseUrl());
+        return urlService;
+    }
+
     /**
      * The ObjectStorageClient allows access to our Storage Provider where thumbnails and sitemap files are stored
      * At the moment we use Amazon S3
@@ -227,4 +246,5 @@ public class AppConfig {
         LOG.info("Creating new objectStorage client");
         return new S3ObjectStorageClient(key,secret,region,bucket);
     }
+
 }

--- a/api2-war/src/main/java/eu/europeana/api2/utils/FieldTripUtils.java
+++ b/api2-war/src/main/java/eu/europeana/api2/utils/FieldTripUtils.java
@@ -17,13 +17,13 @@
 
 package eu.europeana.api2.utils;
 
+import eu.europeana.api2.model.utils.Api2UrlService;
 import eu.europeana.api2.v2.model.xml.rss.fieldtrip.FieldTripImage;
 import eu.europeana.api2.v2.model.xml.rss.fieldtrip.FieldTripItem;
 import eu.europeana.corelib.definitions.edm.beans.ApiBean;
 import eu.europeana.corelib.definitions.edm.beans.BriefBean;
 import eu.europeana.corelib.definitions.edm.beans.RichBean;
 import eu.europeana.corelib.utils.StringArrayUtils;
-import eu.europeana.corelib.web.service.EuropeanaUrlService;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 
@@ -36,14 +36,14 @@ import java.util.regex.Pattern;
 
 public class FieldTripUtils {
 
-    private EuropeanaUrlService urlService;
+    private Api2UrlService urlService;
 
     private final static SimpleDateFormat FIELDTRIP_DATE_FORMATTER = new SimpleDateFormat("EEE, MMM d yyyy HH:mm:ss Z");
     private final static Pattern DESCRIPTION_PATTERN = Pattern.compile("(<description>)(.*?)(</description>)", Pattern.DOTALL);
     private final static Pattern ATTRIBUTION_PATTERN = Pattern.compile("(<attribution>)(.*?)(</attribution>)", Pattern.DOTALL);
 
 
-    public FieldTripUtils(EuropeanaUrlService urlService) {
+    public FieldTripUtils(Api2UrlService urlService) {
         this.urlService = urlService;
     }
 
@@ -59,7 +59,7 @@ public class FieldTripUtils {
      */
     public FieldTripItem createItem(RichBean bean) {
         FieldTripItem item = new FieldTripItem();
-        item.guid = urlService.getPortalRecord(bean.getId()).toString();
+        item.guid = urlService.getRecordPortalUrl(bean.getId());
         item.title = getTitle(bean);
         item.description = extractDescription(bean.getDcDescription());
         item.images = getThumbnail(bean);

--- a/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
+++ b/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
@@ -19,6 +19,7 @@ package eu.europeana.api2.v2.web.controller;
 
 import eu.europeana.api2.ApiLimitException;
 import eu.europeana.api2.model.json.ApiError;
+import eu.europeana.api2.model.utils.Api2UrlService;
 import eu.europeana.api2.utils.FieldTripUtils;
 import eu.europeana.api2.utils.JsonUtils;
 import eu.europeana.api2.utils.XmlUtils;
@@ -63,7 +64,6 @@ import eu.europeana.corelib.utils.StringArrayUtils;
 import eu.europeana.corelib.web.exception.EuropeanaException;
 import eu.europeana.corelib.web.exception.ProblemType;
 import eu.europeana.corelib.web.model.rights.RightReusabilityCategorizer;
-import eu.europeana.corelib.web.service.EuropeanaUrlService;
 import eu.europeana.corelib.web.support.Configuration;
 import eu.europeana.corelib.web.utils.NavigationUtils;
 import eu.europeana.corelib.web.utils.RequestUtils;
@@ -116,7 +116,7 @@ public class SearchController {
     private Configuration configuration;
 
     @Resource
-    private EuropeanaUrlService urlService;
+    private Api2UrlService urlService;
 
     @Resource
     private ApiKeyUtils apiKeyUtils;
@@ -626,7 +626,7 @@ public class SearchController {
             channel.totalResults.value = resultSet.getResultSize();
             for (BriefBean bean : resultSet.getResults()) {
                 Item item = new Item();
-                item.guid = urlService.getPortalRecord(bean.getId()).toString();
+                item.guid = urlService.getRecordPortalUrl(bean.getId());
                 item.title = getTitle(bean);
                 item.description = getDescription(bean);
                 item.link = item.guid;

--- a/api2-war/src/main/java/eu/europeana/api2/web/controller/abstracts/AbstractUserController.java
+++ b/api2-war/src/main/java/eu/europeana/api2/web/controller/abstracts/AbstractUserController.java
@@ -21,6 +21,7 @@ import java.security.Principal;
 
 import javax.annotation.Resource;
 
+import eu.europeana.api2.model.utils.Api2UrlService;
 import eu.europeana.corelib.db.exception.DatabaseException;
 import eu.europeana.corelib.definitions.db.entity.relational.ApiKey;
 import eu.europeana.corelib.definitions.db.entity.relational.User;
@@ -32,7 +33,6 @@ import eu.europeana.api2.v2.model.json.abstracts.UserObject;
 import eu.europeana.corelib.db.service.ApiKeyService;
 import eu.europeana.corelib.db.service.UserService;
 import eu.europeana.corelib.definitions.db.entity.relational.abstracts.EuropeanaUserObject;
-import eu.europeana.corelib.web.service.EuropeanaUrlService;
 
 /**
  * @deprecated 2018-01-09 old MyEuropeana functionality
@@ -47,7 +47,7 @@ public abstract class AbstractUserController {
 	protected ApiKeyService apiKeyService;
 	
 	@Resource
-	private EuropeanaUrlService urlService;
+	private Api2UrlService urlService;
 
 	protected String getApiId(Principal principal) {
 		if (principal instanceof OAuth2Authentication) {
@@ -84,8 +84,8 @@ public abstract class AbstractUserController {
 		to.dateSaved = from.getDateSaved();
 		to.type = from.getDocType();
 		to.edmPreview = from.getEuropeanaObject();
-		to.link = urlService.getApi2RecordJson(wskey, from.getEuropeanaUri()).toString();
-		to.guid = LinkUtils.addCampaignCodes(urlService.getPortalRecord(from.getEuropeanaUri()), wskey);
+		to.link = urlService.getRecordApi2Url(from.getEuropeanaUri(), wskey);
+		to.guid = LinkUtils.addCampaignCodes(urlService.getRecordPortalUrl(from.getEuropeanaUri()), wskey);
 	}
 
 }

--- a/api2-war/src/main/resources/europeana.properties
+++ b/api2-war/src/main/resources/europeana.properties
@@ -1,10 +1,10 @@
 # used in SearchController.searchJson()
 api.rowLimit = 100
 
-# used in UserAdminController, Swagger, corelib.web.service (?)
-api2.url           = https://www.europeana.eu/api
-api2.canonical.url = https://www.europeana.eu/api
-portal.server      = https://www.europeana.eu/
+# Optional base urls for generated links
+portal.baseUrl=http://www-test.eanadev.org
+api2.baseUrl=http://localhost:8080
+
 
 #  Google Fieldtrip collection properties, via SearchController.fieldTripRss()
 gft.channel.2020735.1 = title=National Heritage Board of Estonia
@@ -30,8 +30,6 @@ gft.channel.9200434.3 = language=de
 gft.channel.9200434.4 = link=http://www.onb.ac.at/
 gft.channel.9200434.5 = image=https://www.europeana.eu/GFT9200434.jpg
 
-# used by Corelib-web EuropeanaUrlServiceImpl.getThumbnailUrl()
-imageCacheUrl = https://www.europeana.eu/api/v2/thumbnail-by-url.json?
 
 # Mongo settings with main Europeana database server,
 mongodb.connectionUrl = mongodb://REMOVED:REMOVED@reindexing1.eanadev.org:27017,reindexing2.eanadev.org:27017,reindexing3.eanadev.org:27017/europeana_1

--- a/api2-war/src/main/resources/europeana.properties
+++ b/api2-war/src/main/resources/europeana.properties
@@ -1,7 +1,7 @@
 # used in SearchController.searchJson()
 api.rowLimit = 100
 
-# Optional base urls for generated links
+# Optional alternative base urls for generated links
 portal.baseUrl=http://www-test.eanadev.org
 api2.baseUrl=http://localhost:8080
 


### PR DESCRIPTION
The Api2UrlService now generates all urls for the API and contains loading the baseUrl configuration for Portal and API links. Also fixed namespaces in xml responses (should start with http and not https)
Fixed broken link to Europeana logo in opensearch responses