### PR TITLE
EA-1983: Escape Solr LocalParams in search queries

### DIFF
--- a/api2-war/src/main/java/eu/europeana/api2/config/WebMvcConfig.java
+++ b/api2-war/src/main/java/eu/europeana/api2/config/WebMvcConfig.java
@@ -1,5 +1,6 @@
 package eu.europeana.api2.config;
 
+import eu.europeana.api2.utils.SolrEscapeAnnotationFormatterFactory;
 import eu.europeana.api2.utils.XmlUtils;
 import eu.europeana.api2.v2.model.xml.kml.KmlResponse;
 import eu.europeana.api2.v2.model.xml.rss.RssResponse;
@@ -10,10 +11,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.servlet.ViewResolver;
-import org.springframework.web.servlet.config.annotation.*;
+import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
+import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import org.springframework.web.servlet.view.xml.MarshallingView;
 
@@ -63,5 +68,11 @@ public class WebMvcConfig extends WebMvcConfigurerAdapter {
     @Override
     public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {
         configurer.enable();
+    }
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        super.addFormatters(registry);
+        registry.addFormatterForFieldAnnotation(new SolrEscapeAnnotationFormatterFactory());
     }
 }

--- a/api2-war/src/main/java/eu/europeana/api2/utils/SolrEscape.java
+++ b/api2-war/src/main/java/eu/europeana/api2/utils/SolrEscape.java
@@ -1,0 +1,15 @@
+package eu.europeana.api2.utils;
+
+import java.lang.annotation.*;
+
+
+/**
+ * Annotation used in Spring controller request params.
+ * Parameters with this annotation are handled in {@link SolrEscapeAnnotationFormatterFactory}
+ *
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+public @interface SolrEscape {
+}

--- a/api2-war/src/main/java/eu/europeana/api2/utils/SolrEscapeAnnotationFormatterFactory.java
+++ b/api2-war/src/main/java/eu/europeana/api2/utils/SolrEscapeAnnotationFormatterFactory.java
@@ -1,0 +1,33 @@
+package eu.europeana.api2.utils;
+
+import org.springframework.context.support.EmbeddedValueResolutionSupport;
+import org.springframework.format.AnnotationFormatterFactory;
+import org.springframework.format.Parser;
+import org.springframework.format.Printer;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Formats RequestParams annotated with {@link SolrEscape}
+ */
+public class SolrEscapeAnnotationFormatterFactory extends EmbeddedValueResolutionSupport
+        implements AnnotationFormatterFactory<SolrEscape> {
+    @Override
+    public Set<Class<?>> getFieldTypes() {
+        Set<Class<?>> fieldTypes = new HashSet<>();
+        fieldTypes.add(String.class);
+        return Collections.unmodifiableSet(fieldTypes);
+    }
+
+    @Override
+    public Printer<String> getPrinter(SolrEscape annotation, Class<?> aClass) {
+        return new SolrLocalParamFormatter();
+    }
+
+    @Override
+    public Parser<String> getParser(SolrEscape annotation, Class<?> aClass) {
+        return new SolrLocalParamFormatter();
+    }
+}

--- a/api2-war/src/main/java/eu/europeana/api2/utils/SolrLocalParamFormatter.java
+++ b/api2-war/src/main/java/eu/europeana/api2/utils/SolrLocalParamFormatter.java
@@ -1,0 +1,29 @@
+package eu.europeana.api2.utils;
+
+import org.springframework.format.Parser;
+import org.springframework.format.Printer;
+
+import java.text.ParseException;
+import java.util.Locale;
+
+
+public class SolrLocalParamFormatter implements Printer<String>, Parser<String> {
+    @Override
+    public String print(String str, Locale locale) {
+        return str;
+    }
+
+    /**
+     * Escapes Solr LocalParams from the input string.
+     * LocalParams begin with "{!"
+     *
+     * @param str    input string
+     * @param locale locale.
+     * @return Formatted string
+     * @throws ParseException on exception
+     */
+    @Override
+    public String parse(String str, Locale locale) throws ParseException {
+        return str.replace("{!", "\\{\\!").replace("}", "\\}");
+    }
+}

--- a/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
+++ b/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
@@ -3,6 +3,7 @@ package eu.europeana.api2.v2.web.controller;
 import eu.europeana.api2.model.utils.Api2UrlService;
 import eu.europeana.api2.utils.FieldTripUtils;
 import eu.europeana.api2.utils.JsonUtils;
+import eu.europeana.api2.utils.SolrEscape;
 import eu.europeana.api2.utils.XmlUtils;
 import eu.europeana.api2.v2.exceptions.DateMathParseException;
 import eu.europeana.api2.v2.exceptions.InvalidRangeOrGapException;
@@ -119,13 +120,13 @@ public class SearchController {
 
     public ModelAndView searchJsonPost(
             @RequestParam(value = "wskey") String apikey,
-            @RequestParam(value = "query") String queryString,
+            @SolrEscape @RequestParam(value = "query") String queryString,
             @RequestParam(value = "qf", required = false) String[] refinementArray,
             @RequestParam(value = "reusability", required = false) String[] reusabilityArray,
             @RequestParam(value = "profile", required = false, defaultValue = "standard") String profile,
             @RequestParam(value = "start", required = false, defaultValue = "1") int start,
             @RequestParam(value = "rows", required = false, defaultValue = "12") int rows,
-            @RequestParam(value = "facet", required = false) String[] mixedFacetArray,
+            @SolrEscape @RequestParam(value = "facet", required = false) String[] mixedFacetArray,
             @RequestParam(value = "theme", required = false) String theme,
             @RequestParam(value = "sort", required = false) String sort,
             @RequestParam(value = "colourpalette", required = false) String[] colourPaletteArray,
@@ -135,7 +136,7 @@ public class SearchController {
             @RequestParam(value = "landingpage", required = false) Boolean landingPage,
             @RequestParam(value = "cursor", required = false) String cursorMark,
             @RequestParam(value = "callback", required = false) String callback,
-            @RequestParam(value = "hit.fl", required = false) String hlFl,
+            @SolrEscape @RequestParam(value = "hit.fl", required = false) String hlFl,
             @RequestParam(value = "hit.selectors", required = false) String hlSelectors,
             HttpServletRequest request,
             HttpServletResponse response) throws EuropeanaException {
@@ -155,13 +156,13 @@ public class SearchController {
     @GetMapping(value = "/v2/search.json", produces = MediaType.APPLICATION_JSON_VALUE)
     public ModelAndView searchJsonGet(
             @RequestParam(value = "wskey") String apikey,
-            @RequestParam(value = "query") String queryString,
+            @SolrEscape  @RequestParam(value = "query") String queryString,
             @RequestParam(value = "qf", required = false) String[] refinementArray,
             @RequestParam(value = "reusability", required = false) String[] reusabilityArray,
             @RequestParam(value = "profile", required = false, defaultValue = "standard") String profile,
             @RequestParam(value = "start", required = false, defaultValue = "1") int start,
             @RequestParam(value = "rows", required = false, defaultValue = "12") int rows,
-            @RequestParam(value = "facet", required = false) String[] mixedFacetArray,
+            @SolrEscape @RequestParam(value = "facet", required = false) String[] mixedFacetArray,
             @RequestParam(value = "theme", required = false) String theme,
             @RequestParam(value = "sort", required = false) String sort,
             @RequestParam(value = "colourpalette", required = false) String[] colourPaletteArray,
@@ -171,7 +172,7 @@ public class SearchController {
             @RequestParam(value = "landingpage", required = false) Boolean landingPage,
             @RequestParam(value = "cursor", required = false) String cursorMark,
             @RequestParam(value = "callback", required = false) String callback,
-            @RequestParam(value = "hit.fl", required = false) String hlFl,
+            @SolrEscape @RequestParam(value = "hit.fl", required = false) String hlFl,
             @RequestParam(value = "hit.selectors", required = false) String hlSelectors,
             HttpServletRequest request,
             HttpServletResponse response) throws EuropeanaException {
@@ -686,7 +687,7 @@ public class SearchController {
     @ResponseBody
     @Deprecated
     public KmlResponse searchKml(
-            @RequestParam(value = "query") String queryString,
+            @SolrEscape @RequestParam(value = "query") String queryString,
             @RequestParam(value = "qf", required = false) String[] refinementArray,
             @RequestParam(value = "start", required = false, defaultValue = "1") int start,
             @RequestParam(value = "wskey") String apikey,
@@ -729,7 +730,7 @@ public class SearchController {
             produces = {"application/rss+xml", MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_XHTML_XML_VALUE})
     @ResponseBody
     public ModelAndView openSearchRss(
-            @RequestParam(value = "searchTerms") String queryString,
+            @SolrEscape @RequestParam(value = "searchTerms") String queryString,
             @RequestParam(value = "startIndex", required = false, defaultValue = "1") int start,
             @RequestParam(value = "count", required = false, defaultValue = "12") int count,
             HttpServletResponse response)  throws EuropeanaException {
@@ -789,7 +790,7 @@ public class SearchController {
     @ApiOperation(value = "Google Fieldtrip formatted RSS of selected collections", nickname = "fieldTrip")
     @GetMapping(value = "/v2/search.rss", produces = {MediaType.APPLICATION_XML_VALUE, MediaType.ALL_VALUE})
     public ModelAndView fieldTripRss(
-            @RequestParam(value = "query") String queryTerms,
+            @SolrEscape @RequestParam(value = "query") String queryTerms,
             @RequestParam(value = "offset", required = false, defaultValue = "1") int offset,
             @RequestParam(value = "limit", required = false, defaultValue = "12") int limit,
             @RequestParam(value = "profile", required = false, defaultValue = "FieldTrip") String profile,

--- a/api2-war/src/test/java/eu/europeana/api2/utils/SolrLocalParamFormatterTest.java
+++ b/api2-war/src/test/java/eu/europeana/api2/utils/SolrLocalParamFormatterTest.java
@@ -1,0 +1,19 @@
+package eu.europeana.api2.utils;
+
+import org.junit.Test;
+
+import java.text.ParseException;
+import java.util.Locale;
+
+import static org.junit.Assert.*;
+
+public class SolrLocalParamFormatterTest {
+    SolrLocalParamFormatter formatter = new SolrLocalParamFormatter();
+
+    @Test
+    public void shouldEscapeInputString() throws ParseException {
+        String input = "{! field=test}";
+        String expected = "\\{\\! field=test\\}";
+        assertEquals(expected, formatter.parse(input, Locale.getDefault()));
+    }
+}


### PR DESCRIPTION
_Re-applying changes accidentally deleted during merge_.

- added @SolrEscape annotation
- implemented formatter to escape "{!" and "}" in request params