### PR TITLE
Release api2 2.11.0 hotfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 .DS_Store
 
 # Local user-specific configuration
-**/europeana.user.properties
+**/*europeana.user.properties
 
 # docker stuff
 docker/docker-compose.yml

--- a/api2-war/src/main/java/eu/europeana/api2/v2/model/FacetTag.java
+++ b/api2-war/src/main/java/eu/europeana/api2/v2/model/FacetTag.java
@@ -1,5 +1,6 @@
 package eu.europeana.api2.v2.model;
 
+import eu.europeana.corelib.definitions.solr.TechnicalFacetType;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -28,7 +29,9 @@ public class FacetTag {
     }
 
     public String getLabel() {
-        if (label != null) {
+        if ((StringUtils.isNotBlank(label)) && StringUtils.equals(name, TechnicalFacetType.COLOURPALETTE.getRealName())) {
+            return translateMetisTerms(label);
+        } else if (StringUtils.isNotBlank(label)) {
             return translateMetisTerms(StringUtils.lowerCase(label));
         } else {
             return "";

--- a/api2-war/src/main/java/eu/europeana/api2/v2/service/FacetWrangler.java
+++ b/api2-war/src/main/java/eu/europeana/api2/v2/service/FacetWrangler.java
@@ -93,7 +93,7 @@ public class FacetWrangler {
                  * - match the technical Facet name against the enum TechnicalFacetType
                  * - values associated with the technical Facet are stored in the technicalFacetMap
                  * Note that technical metadata names are encoded numerically (See eu.europeana.technicalfacets) */
-                if (facetField.getName().equalsIgnoreCase("facet_tags")) {
+                if (StringUtils.equalsIgnoreCase(facetField.getName(), "facet_tags")) {
                     for (FacetField.Count encodedTechnicalFacet : facetField.getValues()) {
                         if (StringUtils.isNotEmpty(encodedTechnicalFacet.getName())
                             && encodedTechnicalFacet.getCount() > 0) {
@@ -105,7 +105,7 @@ public class FacetWrangler {
                                     LOG.debug("Decoded technical Facet's name and/or label is empty");
                                     continue;
                                 }
-
+                                
                                 // retrieve a possibly earlier stored count value for this label. If not available,
                                 // initialise at 0L; then add the count value to the Map for this particular label
                                 Integer technicalFacetFieldCount = technicalFacetMap.get(facetTag.getName()).get(facetTag.getLabel());

--- a/api2-war/src/main/java/eu/europeana/api2/v2/utils/ModelUtils.java
+++ b/api2-war/src/main/java/eu/europeana/api2/v2/utils/ModelUtils.java
@@ -104,10 +104,10 @@ public class ModelUtils {
     }
 
     /**
-     * returns a FacetTag object containing the name and label associated with the tag value
+     * returns Map containing the labels and values of the Facets found in the given tag
      *
      * @param tag numerically encoded technical facet tag
-     * @return FacetTag (String name, String label)
+     * @return Map<String label, String value>
      */
     public static Map<String, String> findAllFacetsInTag(Integer tag) {
         Map<String, String> result = new HashMap<>();

--- a/api2-war/src/main/java/eu/europeana/api2/v2/utils/ModelUtils.java
+++ b/api2-war/src/main/java/eu/europeana/api2/v2/utils/ModelUtils.java
@@ -6,7 +6,6 @@ import eu.europeana.api2.v2.model.json.view.submodel.SpellCheck;
 import eu.europeana.corelib.definitions.solr.SolrFacetType;
 import eu.europeana.corelib.definitions.solr.TechnicalFacetType;
 import eu.europeana.indexing.solr.facet.EncodedFacet;
-import eu.europeana.indexing.solr.facet.value.*;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.solr.client.solrj.response.SpellCheckResponse;
@@ -25,6 +24,7 @@ public class ModelUtils {
     private static final String SOLRFACETS      = "solrfacets";
     private static final String CUSTOMFACETS    = "customfacets";
     private static final String DEFAULT         = "DEFAULT";
+    private static final String NEWLINE         = System.lineSeparator();
 
     private static final int          FACET_LIMIT        = 150;
     // static goodies: Lists containing the enum Facet type names
@@ -33,10 +33,10 @@ public class ModelUtils {
     private static final List<String> enumFacetList      = new ArrayList<>();
 
     static {
-        for (final TechnicalFacetType technicalFacet : TechnicalFacetType.values()) {
+        for (final var technicalFacet : TechnicalFacetType.values()) {
             technicalFacetList.add(technicalFacet.name());
         }
-        for (final SolrFacetType solrFacet : SolrFacetType.values()) {
+        for (final var solrFacet : SolrFacetType.values()) {
             solrFacetList.add(solrFacet.toString());
         }
         enumFacetList.addAll(technicalFacetList);
@@ -53,49 +53,49 @@ public class ModelUtils {
      */
     public static FacetTag decodeFacetTag(Integer tag) {
 
-        final MediaTypeEncoding mediaType = EncodedFacet.MEDIA_TYPE.decodeValue(tag);
-        final MimeTypeEncoding  mimeType  = EncodedFacet.MIME_TYPE.decodeValue(tag);
+        final var mediaType = EncodedFacet.MEDIA_TYPE.decodeValue(tag);
+        final var mimeType  = EncodedFacet.MIME_TYPE.decodeValue(tag);
         if (mimeType != null) {
             return new FacetTag("MIME_TYPE", mimeType.getValue());
         }
 
         switch (mediaType) {
             case IMAGE:
-                ImageAspectRatio imageAspectRatio = EncodedFacet.IMAGE_ASPECT_RATIO.decodeValue(tag);
+                var imageAspectRatio = EncodedFacet.IMAGE_ASPECT_RATIO.decodeValue(tag);
                 if (imageAspectRatio != null) {
                     return new FacetTag("IMAGE_ASPECTRATIO", imageAspectRatio.toString());
                 }
-                ImageColorEncoding imageColorEncoding = EncodedFacet.IMAGE_COLOR_ENCODING.decodeValue(tag);
+                var imageColorEncoding = EncodedFacet.IMAGE_COLOR_ENCODING.decodeValue(tag);
                 if (imageColorEncoding != null) {
                     return new FacetTag("COLOURPALETTE", imageColorEncoding.getHexStringWithHash());
                 }
-                ImageColorSpace imageColorSpace = EncodedFacet.IMAGE_COLOR_SPACE.decodeValue(tag);
+                var imageColorSpace = EncodedFacet.IMAGE_COLOR_SPACE.decodeValue(tag);
                 if (imageColorSpace != null) {
                     return new FacetTag("IMAGE_COLOUR", imageColorSpace.toString());
                 }
-                ImageSize imageSize = EncodedFacet.IMAGE_SIZE.decodeValue(tag);
+                var imageSize = EncodedFacet.IMAGE_SIZE.decodeValue(tag);
                 if (imageSize != null) {
                     return new FacetTag("IMAGE_SIZE", imageSize.toString());
                 }
                 return new FacetTag("", "");
             case AUDIO:
-                AudioDuration audioDuration = EncodedFacet.AUDIO_DURATION.decodeValue(tag);
+                var audioDuration = EncodedFacet.AUDIO_DURATION.decodeValue(tag);
                 if (audioDuration != null) {
                     return new FacetTag("SOUND_DURATION", audioDuration.toString());
                 }
-                AudioQuality audioQuality = EncodedFacet.AUDIO_QUALITY.decodeValue(tag);
+                var audioQuality = EncodedFacet.AUDIO_QUALITY.decodeValue(tag);
                 if (audioQuality != null) {
                     return new FacetTag("SOUND_HQ", audioQuality.toString());
                 }
                 return new FacetTag("", "");
             case VIDEO:
-                VideoDuration videoDuration = EncodedFacet.VIDEO_DURATION.decodeValue(tag);
+                var videoDuration = EncodedFacet.VIDEO_DURATION.decodeValue(tag);
                 if (videoDuration != null) {
                     return new FacetTag("VIDEO_DURATION", videoDuration.toString());
                 }
-                VideoQuality videoQualityn = EncodedFacet.VIDEO_QUALITY.decodeValue(tag);
-                if (videoQualityn != null) {
-                    return new FacetTag("VIDEO_HD", videoQualityn.toString());
+                var videoQuality = EncodedFacet.VIDEO_QUALITY.decodeValue(tag);
+                if (videoQuality != null) {
+                    return new FacetTag("VIDEO_HD", videoQuality.toString());
                 }
                 return new FacetTag("", "");
             default:
@@ -103,13 +103,76 @@ public class ModelUtils {
         }
     }
 
+    /**
+     * returns a FacetTag object containing the name and label associated with the tag value
+     *
+     * @param tag numerically encoded technical facet tag
+     * @return FacetTag (String name, String label)
+     */
+    public static Map<String, String> findAllFacetsInTag(Integer tag) {
+        Map<String, String> result = new HashMap<>();
+
+        final var mediaType = EncodedFacet.MEDIA_TYPE.decodeValue(tag);
+        final var mimeType  = EncodedFacet.MIME_TYPE.decodeValue(tag);
+        if (mimeType != null) {
+            result.put("MIME_TYPE", mimeType.getValue());
+        }
+
+        switch (mediaType) {
+            case IMAGE:
+                var imageAspectRatio = EncodedFacet.IMAGE_ASPECT_RATIO.decodeValue(tag);
+                if (imageAspectRatio != null) {
+                    result.put("IMAGE_ASPECTRATIO", imageAspectRatio.toString());
+                }
+                var imageColorEncoding = EncodedFacet.IMAGE_COLOR_ENCODING.decodeValue(tag);
+                if (imageColorEncoding != null) {
+                    result.put("COLOURPALETTE", imageColorEncoding.getHexStringWithHash());
+                }
+                var imageColorSpace = EncodedFacet.IMAGE_COLOR_SPACE.decodeValue(tag);
+                if (imageColorSpace != null) {
+                    result.put("IMAGE_COLOUR", imageColorSpace.toString());
+                }
+                var imageSize = EncodedFacet.IMAGE_SIZE.decodeValue(tag);
+                if (imageSize != null) {
+                    result.put("IMAGE_SIZE", imageSize.toString());
+                }
+                break;
+            case AUDIO:
+                var audioDuration = EncodedFacet.AUDIO_DURATION.decodeValue(tag);
+                if (audioDuration != null) {
+                    result.put("SOUND_DURATION", audioDuration.toString());
+                }
+                var audioQuality = EncodedFacet.AUDIO_QUALITY.decodeValue(tag);
+                if (audioQuality != null) {
+                    result.put("SOUND_HQ", audioQuality.toString());
+                }
+                break;
+            case VIDEO:
+                var videoDuration = EncodedFacet.VIDEO_DURATION.decodeValue(tag);
+                if (videoDuration != null) {
+                    result.put("VIDEO_DURATION", videoDuration.toString());
+                }
+                var videoQuality = EncodedFacet.VIDEO_QUALITY.decodeValue(tag);
+                if (videoQuality != null) {
+                    result.put("VIDEO_HD", videoQuality.toString());
+                }
+                break;
+            case TEXT:
+                result.put("TEXT_FACET", "(not specified further)");
+                break;
+            default:
+                break;
+        }
+        return result;
+    }
+
     public static SpellCheck convertSpellCheck(SpellCheckResponse response) {
         if (response != null) {
-            SpellCheck spellCheck = new SpellCheck();
+            var spellCheck = new SpellCheck();
             spellCheck.correctlySpelled = response.isCorrectlySpelled();
             for (Suggestion suggestion : response.getSuggestions()) {
-                for (int i = 0; i < suggestion.getNumFound(); i++) {
-                    LabelFrequency value = new LabelFrequency();
+                for (var i = 0; i < suggestion.getNumFound(); i++) {
+                    var value = new LabelFrequency();
                     value.label = suggestion.getAlternatives().get(i);
                     value.count = suggestion.getAlternativeFrequencies().get(i).longValue();
                     spellCheck.suggestions.add(value);
@@ -138,13 +201,12 @@ public class ModelUtils {
         }
 
         if (ArrayUtils.isNotEmpty(mixedFacetArray)) {
-            List<String> customSolrFacetList = ((List<String>) CollectionUtils.subtract(Arrays.asList(mixedFacetArray),
-                                                                                        enumFacetList));
+            var customSolrFacetList = ((List<String>) CollectionUtils.subtract(Arrays.asList(mixedFacetArray),
+                                                                               enumFacetList));
             if (customSolrFacetList.contains(DEFAULT)) customSolrFacetList.remove(DEFAULT);
             customSolrFacets = (customSolrFacetList).toArray(new String[0]);
             if (defaultFacetsRequested) {
-                facetListMap.put(CUSTOMFACETS,
-                                 safelyLimitArray(customSolrFacets, FACET_LIMIT - enumFacetList.size()));
+                facetListMap.put(CUSTOMFACETS, safelyLimitArray(customSolrFacets, FACET_LIMIT - enumFacetList.size()));
             } else {
                 facetListMap.put(CUSTOMFACETS,
                                  safelyLimitArray(customSolrFacets,

--- a/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
+++ b/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
@@ -563,24 +563,24 @@ public class SearchController {
 
         // Encode the faceted refinements ...
         if (hasImageRefinements) {
-            filterTags.addAll(facetEncoder.getImageFacetValueCodes(imageMimeTypeRefinements,
+            filterTags.addAll(facetEncoder.getImageFacetSearchCodes(imageMimeTypeRefinements,
                                                                     imageSizeRefinements,
                                                                     imageColourSpaceRefinements,
                                                                     imageAspectRatioRefinements,
                                                                     imageColourPaletteRefinements));
         }
         if (hasSoundRefinements) {
-            filterTags.addAll(facetEncoder.getAudioFacetValueCodes(soundMimeTypeRefinements,
+            filterTags.addAll(facetEncoder.getAudioFacetSearchCodes(soundMimeTypeRefinements,
                                                                     soundHQRefinements,
                                                                     soundDurationRefinements));
         }
         if (hasVideoRefinements) {
-            filterTags.addAll(facetEncoder.getVideoFacetValueCodes(videoMimeTypeRefinements,
+            filterTags.addAll(facetEncoder.getVideoFacetSearchCodes(videoMimeTypeRefinements,
                                                                     videoHDRefinements,
                                                                     videoDurationRefinements));
         }
         if (!otherMimeTypeRefinements.isEmpty()) {
-            filterTags.addAll(facetEncoder.getTextFacetValueCodes(otherMimeTypeRefinements));
+            filterTags.addAll(facetEncoder.getTextFacetSearchCodes(otherMimeTypeRefinements));
         }
 
         if (LOG.isDebugEnabled()) {

--- a/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
+++ b/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
@@ -72,6 +72,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static eu.europeana.api2.v2.utils.ModelUtils.decodeFacetTag;
+import static eu.europeana.api2.v2.utils.ModelUtils.findAllFacetsInTag;
 
 /**
  * Controller that handles all search requests (search.json, opensearch.rss, search.rss, and search.kml)
@@ -921,21 +922,39 @@ public class SearchController {
     }
 
     /**
-     * Temporary method to facilitate debugging the facet tags
+     * Method to find all encoded facets in tags
+     *
+     * @return the JSON response
+     */
+    @SwaggerIgnore
+    @GetMapping(value = "/v2/decodetags.json", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ModelAndView decodeTags(
+            @RequestParam(value = "tag") String tag) {
+
+        FacetTag facetTag;
+        if (tag.matches("[0-9]+") && tag.length() > 7) {
+            return JsonUtils.toJson(findAllFacetsInTag(Integer.valueOf(tag)));
+        } else {
+            return JsonUtils.toJson("Cannot decode this tag: it must be numerical and 8 digits long");
+        }
+    }
+
+    /**
+     * Method to facilitate debugging the facet tags
      *
      * @return the JSON response
      */
     @SwaggerIgnore
     @GetMapping(value = "/v2/tagdecoder.json", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ModelAndView searchJson(
+    public ModelAndView tagDecoder(
             @RequestParam(value = "tag") String tag) {
 
         FacetTag facetTag;
         if (tag.matches("[0-9]+") && tag.length() > 7) {
             facetTag = decodeFacetTag(Integer.valueOf(tag));
         } else {
-            facetTag =  new FacetTag("You're not doing it right, dude / diderina",
-                                     "a tag must be numerical and 8 digits long");
+            facetTag =  new FacetTag("Cannot decode this tag:",
+                                     "it must be numerical and 8 digits long");
         }
         return JsonUtils.toJson(facetTag.getName() + ": " + facetTag.getLabel());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <corelib.version>2.11.0</corelib.version>
-        <metis.version>2</metis.version>
+        <metis.version>3-SNAPSHOT</metis.version>
 
         <httpclient.version>4.5.2</httpclient.version>
         <jackson.version>2.9.9</jackson.version>


### PR DESCRIPTION
Hotfix for uppercase hex colour labels for Colourpalette facet. This is (was) dependent on a Snaphot Metis version, though that may no longer be the case - needs to be checked and possibly changed before merging this PR, otherwise we'll introduce a snapshot dependency.