### PR TITLE
added (american-spelled) foaf_organiZations

### DIFF
--- a/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/BriefView.java
+++ b/api2-model/src/main/java/eu/europeana/api2/v2/model/json/view/BriefView.java
@@ -60,6 +60,11 @@ public class BriefView extends IdBeanImpl implements BriefBean {
     }
 
     @Override
+    public String[] getOrganizations() {
+        return bean.getOrganizations();
+    }
+
+    @Override
     public String[] getEdmIsShownBy() {
         return bean.getEdmIsShownBy();
     }


### PR DESCRIPTION
In case you need a test URL that has that field available, try 
`../api/v2/search.json?query=paris&sort=europeana_id%20desc&profile=debug&wskey=...`

I still don't understand where this field is now added. According to Monica, it was added and indexed in http://reindex.eanadev.org:9393/solr but she added that it might also be available in Production because Simon "added it directly" there _(Twilight Zone music)_. Because neither Monica, I, nor anyone else I asked has a clue what _adding directly_ means in this context, here's the route to the Solr instance it was added to in the regular way, using indexing:

```
solr1.id            = solr-reindex-prod-publish3
solr1.url           = http://reindex.eanadev.org:9393/solr
solr1.zookeeper.url = reindex.eanadev.org:2383
solr1.core          = search_production_publish_3
```