### PR TITLE
Ea 3828 internal and newspaper routing

### DIFF
--- a/api2-model/src/main/java/eu/europeana/api2/model/utils/RouteMatcher.java
+++ b/api2-model/src/main/java/eu/europeana/api2/model/utils/RouteMatcher.java
@@ -26,16 +26,16 @@ public class RouteMatcher {
         // exact matching
         T result = sourceMap.get(topLevelName);
         if (result != null) {
-            // debugging internal routes for API-gateway-routed requests
-            LOG.info("Exact routes match on : |{}|", topLevelName);
+            // tracing internal routes for API-gateway-routed requests
+            LOG.trace("Exact routes match on : |{}|", topLevelName);
             return Optional.of(result);
         }
 
         // fallback 1: try to match with "contains"
         for (Map.Entry<String, T> entry : sourceMap.entrySet()) {
             if (topLevelName.contains(entry.getKey())) {
-                // debugging internal routes for API-gateway-routed requests
-                LOG.info("'Contains' routes match on : |{}|", topLevelName);
+                // tracing internal routes for API-gateway-routed requests
+                LOG.trace("'Contains' routes match on : |{}|", topLevelName);
                 return Optional.ofNullable(entry.getValue());
             }
         }

--- a/api2-model/src/main/java/eu/europeana/api2/model/utils/RouteMatcher.java
+++ b/api2-model/src/main/java/eu/europeana/api2/model/utils/RouteMatcher.java
@@ -1,9 +1,14 @@
 package eu.europeana.api2.model.utils;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.util.Map;
 import java.util.Optional;
 
 public class RouteMatcher {
+    
+    private static final Logger LOG = LogManager.getLogger(RouteMatcher.class);
 
     private RouteMatcher() {
         // hide implicit constructor
@@ -16,16 +21,21 @@ public class RouteMatcher {
     public static <T> Optional<T> getEntryForRoute(String route, Map<String, T> sourceMap) {
         // make sure we use only the highest level part for matching and not the FQDN
         String topLevelName = getTopLevelName(route);
+        
 
         // exact matching
         T result = sourceMap.get(topLevelName);
         if (result != null) {
+            // debugging internal routes for API-gateway-routed requests
+            LOG.info("Exact routes match on : |{}|", topLevelName);
             return Optional.of(result);
         }
 
         // fallback 1: try to match with "contains"
         for (Map.Entry<String, T> entry : sourceMap.entrySet()) {
             if (topLevelName.contains(entry.getKey())) {
+                // debugging internal routes for API-gateway-routed requests
+                LOG.info("'Contains' routes match on : |{}|", topLevelName);
                 return Optional.ofNullable(entry.getValue());
             }
         }

--- a/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
+++ b/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
@@ -256,7 +256,7 @@ public class SearchController extends BaseController {
         throws EuropeanaException, HttpException {
         
         // debugging internal routes for API-gateway-routed requests
-        LOG.warn("Incoming request comes from server: |{}|", request.getServerName());
+        LOG.info("Incoming request comes from server: |{}|", request.getServerName());
         
         // get the profiles
         Set<Profile> profiles = ProfileUtils.getProfiles(profile);

--- a/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
+++ b/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
@@ -256,7 +256,7 @@ public class SearchController extends BaseController {
         throws EuropeanaException, HttpException {
         
         // debugging internal routes for API-gateway-routed requests
-        LOG.info("Incoming request comes from server: |{}|", request.getServerName());
+        LOG.trace("Incoming request comes from server: |{}|", request.getServerName());
         
         // get the profiles
         Set<Profile> profiles = ProfileUtils.getProfiles(profile);

--- a/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
+++ b/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
@@ -900,6 +900,7 @@ public class SearchController extends BaseController {
 
         SearchResults<? extends IdBean> result = createResults(apiKey, profiles, query, clazz, request.getServerName(),
                 translateTargetLang, filterLanguages, request, response,isRefinementDivisionRequired );
+        System.out.println("Incoming request comes from server: " + request.getServerName());
         if (profiles.contains(Profile.PARAMS)) {
             result.addParams(RequestUtils.getParameterMap(request), "apikey");
             result.addParam("profile", profile);

--- a/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
+++ b/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
@@ -254,7 +254,10 @@ public class SearchController extends BaseController {
         HttpServletRequest request,
         HttpServletResponse response)
         throws EuropeanaException, HttpException {
-
+        
+        // debugging internal routes for API-gateway-routed requests
+        LOG.warn("Incoming request comes from server: |{}|", request.getServerName());
+        
         // get the profiles
         Set<Profile> profiles = ProfileUtils.getProfiles(profile);
 
@@ -900,7 +903,7 @@ public class SearchController extends BaseController {
 
         SearchResults<? extends IdBean> result = createResults(apiKey, profiles, query, clazz, request.getServerName(),
                 translateTargetLang, filterLanguages, request, response,isRefinementDivisionRequired );
-        System.out.println("Incoming request comes from server: " + request.getServerName());
+        
         if (profiles.contains(Profile.PARAMS)) {
             result.addParams(RequestUtils.getParameterMap(request), "apikey");
             result.addParam("profile", profile);

--- a/k8s/overlays/canary/ingress-acceptance.properties.yaml.template
+++ b/k8s/overlays/canary/ingress-acceptance.properties.yaml.template
@@ -44,7 +44,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: search-api-service
+                name: newspapers-search-service
                 port:
                   number: 80
 ---

--- a/k8s/overlays/canary/ingress-acceptance.properties.yaml.template
+++ b/k8s/overlays/canary/ingress-acceptance.properties.yaml.template
@@ -12,12 +12,12 @@ spec:
   ingressClassName: public-iks-k8s-nginx
   tls:
     - hosts:
-        - ${K8S_HOSTNAME_1}
-        - ${K8S_HOSTNAME_2}
-        - ${K8S_HOSTNAME_3}
+        - ${K8S_HOSTNAME_SEARCH1}
+        - ${K8S_HOSTNAME_SEARCH2}
+        - ${K8S_HOSTNAME_NEWSPAPERS}
       secretName: ${K8S_HOSTNAME_SECRET_1}
   rules:
-    - host: ${K8S_HOSTNAME_1}
+    - host: ${K8S_HOSTNAME_SEARCH1}
       http:
         paths:
           - path: /
@@ -27,7 +27,7 @@ spec:
                 name: search-api-service
                 port:
                   number: 80
-    - host: ${K8S_HOSTNAME_2}
+    - host: ${K8S_HOSTNAME_SEARCH2}
       http:
         paths:
           - path: /
@@ -37,7 +37,8 @@ spec:
                 name: search-api-service
                 port:
                   number: 80
-    - host: ${K8S_HOSTNAME_3}
+    # We define a separate service for newspapers so the API gateway can use that
+    - host: ${K8S_HOSTNAME_NEWSPAPERS}
       http:
         paths:
           - path: /
@@ -56,10 +57,10 @@ spec:
   ingressClassName: public-iks-k8s-nginx
   tls:
     - hosts:
-        - ${K8S_HOSTNAME_4}
+        - ${K8S_HOSTNAME_SEARCH4}
       secretName: ${K8S_HOSTNAME_SECRET_4}
   rules:
-    - host: ${K8S_HOSTNAME_4}
+    - host: ${K8S_HOSTNAME_SEARCH4}
       http:
         paths:
           - path: /

--- a/k8s/overlays/canary/ingress-prod.properties.yaml.template
+++ b/k8s/overlays/canary/ingress-prod.properties.yaml.template
@@ -9,31 +9,54 @@ metadata:
     nginx.ingress.kubernetes.io/canary-weight: 0
 spec:
   ingressClassName: public-iks-k8s-nginx
-  rules:
-    - host: ${K8S_HOSTNAME_1}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: search-api-service
-                port:
-                  number: 80
-    - host: ${K8S_HOSTNAME_2}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: search-api-service
-                port:
-                  number: 80
   tls:
     - hosts:
-        - ${K8S_HOSTNAME_1}
+        - ${K8S_HOSTNAME_SEARCH1}
       secretName: ${K8S_HOSTNAME_SECRET_1}
     - hosts:
-        - ${K8S_HOSTNAME_2}
+        - ${K8S_HOSTNAME_SEARCH2}
+        - ${K8S_HOSTNAME_SEARCH3}
+        - ${K8S_HOSTNAME_NEWSPAPERS}
       secretName: ${K8S_HOSTNAME_SECRET_2}
+  rules:
+    - host: ${K8S_HOSTNAME_SEARCH1}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: search-api-service
+                port:
+                  number: 80
+    - host: ${K8S_HOSTNAME_SEARCH2}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: search-api-service
+                port:
+                  number: 80
+    - host: ${K8S_HOSTNAME_SEARCH3}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: search-api-service
+                port:
+                  number: 80
+    # We define a separate service for newspapers so the API gateway can use that
+    - host: ${K8S_HOSTNAME_NEWSPAPERS}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: newspapers-search-service
+                port:
+                  number: 80

--- a/k8s/overlays/canary/ingress-test.properties.yaml.template
+++ b/k8s/overlays/canary/ingress-test.properties.yaml.template
@@ -13,6 +13,7 @@ spec:
   tls:
     - hosts:
         - ${K8S_HOSTNAME_1}
+        - ${K8S_HOSTNAME_2}
       secretName: ${K8S_HOSTNAME_SECRET_1}
   rules:
     - host: ${K8S_HOSTNAME_1}
@@ -23,5 +24,16 @@ spec:
             backend:
               service:
                 name: search-api-service
+                port:
+                  number: 80
+
+    - host: ${K8S_HOSTNAME_2}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: newspaper-search-service
                 port:
                   number: 80

--- a/k8s/overlays/canary/ingress-test.properties.yaml.template
+++ b/k8s/overlays/canary/ingress-test.properties.yaml.template
@@ -12,11 +12,12 @@ spec:
   ingressClassName: public-iks-k8s-nginx
   tls:
     - hosts:
-        - ${K8S_HOSTNAME_1}
-        - ${K8S_HOSTNAME_2}
+        - ${K8S_HOSTNAME_SEARCH1}
+        - ${K8S_HOSTNAME_SEARCH2}
+        - ${K8S_HOSTNAME_NEWSPAPERS}
       secretName: ${K8S_HOSTNAME_SECRET_1}
   rules:
-    - host: ${K8S_HOSTNAME_1}
+    - host: ${K8S_HOSTNAME_SEARCH1}
       http:
         paths:
           - path: /
@@ -26,8 +27,18 @@ spec:
                 name: search-api-service
                 port:
                   number: 80
-
-    - host: ${K8S_HOSTNAME_2}
+    - host: ${K8S_HOSTNAME_SEARCH2}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: search-api-service
+                port:
+                  number: 80
+    # We define a separate service for newspapers so the API gateway can use that
+    - host: ${K8S_HOSTNAME_NEWSPAPERS}
       http:
         paths:
           - path: /

--- a/k8s/overlays/canary/ingress-test.properties.yaml.template
+++ b/k8s/overlays/canary/ingress-test.properties.yaml.template
@@ -34,6 +34,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: newspaper-search-service
+                name: newspapers-search-service
                 port:
                   number: 80

--- a/k8s/overlays/canary/service.yaml
+++ b/k8s/overlays/canary/service.yaml
@@ -18,4 +18,4 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: 8080s
+      targetPort: 8080

--- a/k8s/overlays/canary/service.yaml
+++ b/k8s/overlays/canary/service.yaml
@@ -12,7 +12,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: newspaper-search-service
+  name: newspapers-search-service
 spec:
   # selector provided via Kustomize
   ports:

--- a/k8s/overlays/canary/service.yaml
+++ b/k8s/overlays/canary/service.yaml
@@ -8,3 +8,14 @@ spec:
     - name: http
       port: 80
       targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: newspaper-search-service
+spec:
+  # selector provided via Kustomize
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080s

--- a/k8s/overlays/cloud/ingress-acceptance.properties.yaml.template
+++ b/k8s/overlays/cloud/ingress-acceptance.properties.yaml.template
@@ -40,7 +40,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: search-api-service
+                name: newspapers-search-service
                 port:
                   number: 80
 ---

--- a/k8s/overlays/cloud/ingress-acceptance.properties.yaml.template
+++ b/k8s/overlays/cloud/ingress-acceptance.properties.yaml.template
@@ -8,12 +8,12 @@ spec:
   ingressClassName: public-iks-k8s-nginx
   tls:
     - hosts:
-        - ${K8S_HOSTNAME_1}
-        - ${K8S_HOSTNAME_2}
-        - ${K8S_HOSTNAME_3}
+        - ${K8S_HOSTNAME_SEARCH1}
+        - ${K8S_HOSTNAME_SEARCH2}
+        - ${K8S_HOSTNAME_NEWSPAPERS}
       secretName: ${K8S_HOSTNAME_SECRET_1}
   rules:
-    - host: ${K8S_HOSTNAME_1}
+    - host: ${K8S_HOSTNAME_SEARCH1}
       http:
         paths:
           - path: /
@@ -23,7 +23,7 @@ spec:
                 name: search-api-service
                 port:
                   number: 80
-    - host: ${K8S_HOSTNAME_2}
+    - host: ${K8S_HOSTNAME_SEARCH2}
       http:
         paths:
           - path: /
@@ -33,7 +33,8 @@ spec:
                 name: search-api-service
                 port:
                   number: 80
-    - host: ${K8S_HOSTNAME_3}
+    # We define a separate service for newspapers so the API gateway can use that
+    - host: ${K8S_HOSTNAME_NEWSPAPERS}
       http:
         paths:
           - path: /
@@ -52,10 +53,10 @@ spec:
   ingressClassName: public-iks-k8s-nginx
   tls:
     - hosts:
-        - ${K8S_HOSTNAME_4}
+        - ${K8S_HOSTNAME_SEARCH4}
       secretName: ${K8S_HOSTNAME_SECRET_4}
   rules:
-    - host: ${K8S_HOSTNAME_4}
+    - host: ${K8S_HOSTNAME_SEARCH4}
       http:
         paths:
           - path: /

--- a/k8s/overlays/cloud/ingress-prod.properties.yaml.template
+++ b/k8s/overlays/cloud/ingress-prod.properties.yaml.template
@@ -1,62 +1,61 @@
 # Server aliases don't work well with tls secrets when using multiple domains, so we declare each production route separately
-# K8S_HOSTNAME_1 is europeana.eu subdomain, K8S_HOSTNAME_2, K8S_HOSTNAME_3 and K8S_HOSTNAME_4 are eanadev.org subdomains
+# K8S_HOSTNAME_SEARCH1 is europeana.eu subdomain, the rest are eanadev.org subdomains
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: search-api-ingress
 spec:
   ingressClassName: public-iks-k8s-nginx
-  rules:
-    - host: ${K8S_HOSTNAME_1}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: search-api-service
-                port:
-                  number: 80
-
-    - host: ${K8S_HOSTNAME_2}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: search-api-service
-                port:
-                  number: 80
-
-    - host: ${K8S_HOSTNAME_3}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: search-api-service
-                port:
-                  number: 80
-
-    - host: ${K8S_HOSTNAME_4}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: search-api-service
-                port:
-                  number: 80
-
   tls:
     - hosts:
-        - ${K8S_HOSTNAME_1}
+        - ${K8S_HOSTNAME_SEARCH1}
       secretName: ${K8S_HOSTNAME_SECRET_1}
     - hosts:
-        - ${K8S_HOSTNAME_2}
-        - ${K8S_HOSTNAME_3}
-        - ${K8S_HOSTNAME_4}
+        - ${K8S_HOSTNAME_SEARCH2}
+        - ${K8S_HOSTNAME_SEARCH3}
+        - ${K8S_HOSTNAME_NEWSPAPERS}
       secretName: ${K8S_HOSTNAME_SECRET_2}
+  rules:
+    - host: ${K8S_HOSTNAME_SEARCH1}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: search-api-service
+                port:
+                  number: 80
+    - host: ${K8S_HOSTNAME_SEARCH2}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: search-api-service
+                port:
+                  number: 80
+    - host: ${K8S_HOSTNAME_SEARCH3}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: search-api-service
+                port:
+                  number: 80
+    # We define a separate service for newspapers so the API gateway can use that
+    - host: ${K8S_HOSTNAME_NEWSPAPERS}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: newspapers-search-service
+                port:
+                  number: 80
+
+

--- a/k8s/overlays/cloud/ingress-test.properties.yaml.template
+++ b/k8s/overlays/cloud/ingress-test.properties.yaml.template
@@ -9,6 +9,7 @@ spec:
   tls:
     - hosts:
         - ${K8S_HOSTNAME_1}
+        - ${K8S_HOSTNAME_2}
       secretName: ${K8S_HOSTNAME_SECRET_1}
   rules:
     - host: ${K8S_HOSTNAME_1}
@@ -21,3 +22,15 @@ spec:
                 name: search-api-service
                 port:
                   number: 80
+
+    - host: ${K8S_HOSTNAME_2}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: newspaper-search-service
+                port:
+                  number: 80
+                  

--- a/k8s/overlays/cloud/ingress-test.properties.yaml.template
+++ b/k8s/overlays/cloud/ingress-test.properties.yaml.template
@@ -33,4 +33,3 @@ spec:
                 name: newspaper-search-service
                 port:
                   number: 80
-                  

--- a/k8s/overlays/cloud/ingress-test.properties.yaml.template
+++ b/k8s/overlays/cloud/ingress-test.properties.yaml.template
@@ -30,6 +30,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: newspaper-search-service
+                name: newspapers-search-service
                 port:
                   number: 80

--- a/k8s/overlays/cloud/ingress-test.properties.yaml.template
+++ b/k8s/overlays/cloud/ingress-test.properties.yaml.template
@@ -8,11 +8,12 @@ spec:
   ingressClassName: public-iks-k8s-nginx
   tls:
     - hosts:
-        - ${K8S_HOSTNAME_1}
-        - ${K8S_HOSTNAME_2}
+        - ${K8S_HOSTNAME_SEARCH1}
+        - ${K8S_HOSTNAME_SEARCH2}
+        - ${K8S_HOSTNAME_NEWSPAPERS}
       secretName: ${K8S_HOSTNAME_SECRET_1}
   rules:
-    - host: ${K8S_HOSTNAME_1}
+    - host: ${K8S_HOSTNAME_SEARCH1}
       http:
         paths:
           - path: /
@@ -22,8 +23,18 @@ spec:
                 name: search-api-service
                 port:
                   number: 80
-
-    - host: ${K8S_HOSTNAME_2}
+    - host: ${K8S_HOSTNAME_SEARCH2}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: search-api-service
+                port:
+                  number: 80
+    # We define a separate service for newspapers so the API gateway can use that
+    - host: ${K8S_HOSTNAME_NEWSPAPERS}
       http:
         paths:
           - path: /

--- a/k8s/overlays/cloud/service.yaml
+++ b/k8s/overlays/cloud/service.yaml
@@ -18,4 +18,4 @@ spec:
   ports:
     - name: http
       port: 80
-      targetPort: 8080s
+      targetPort: 8080

--- a/k8s/overlays/cloud/service.yaml
+++ b/k8s/overlays/cloud/service.yaml
@@ -12,7 +12,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: newspaper-search-service
+  name: newspapers-search-service
 spec:
   # selector provided via Kustomize
   ports:

--- a/k8s/overlays/cloud/service.yaml
+++ b/k8s/overlays/cloud/service.yaml
@@ -8,3 +8,14 @@ spec:
     - name: http
       port: 80
       targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: newspaper-search-service
+spec:
+  # selector provided via Kustomize
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080s


### PR DESCRIPTION
This branch contains some changes that add a separate Service for Newspapers Search. 
A hostname for Newspapers Search was added to the Ingress Test template and the existing Newspapers Search host rule in the Ingress Acceptance template was directed to the new Service.

There were no changes in Corelib.