### PR TITLE
Ea 3979 fix refinement concatenation

### DIFF
--- a/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
+++ b/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
@@ -866,7 +866,7 @@ public class SearchController extends BaseController {
         }
 
         SearchResults<? extends IdBean> result = createResults(apiKey, profiles, query, clazz, request.getServerName(),
-                translateTargetLang, filterLanguages, request, response,isRefinementDivisionRequired );
+                translateTargetLang, filterLanguages, request, response, isRefinementDivisionRequired, true);
 
         if (profiles.contains(Profile.PARAMS)) {
             result.addParams(RequestUtils.getParameterMap(request), "apikey");
@@ -1321,8 +1321,8 @@ public class SearchController extends BaseController {
                                                               List<Language> filterLanguages,
                                                               HttpServletRequest servletRequest,
                                                               HttpServletResponse servletResponse,
-        boolean isToDivideQueryRefinements,boolean isV3) throws EuropeanaException {
-
+                                                              boolean isToDivideQueryRefinements,
+                                                              boolean isV3) throws EuropeanaException {
         SearchResults<T> response = new SearchResults<>(apiKey);
         ResultSet<T>     resultSet;
 

--- a/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
+++ b/api2-war/src/main/java/eu/europeana/api2/v2/web/controller/SearchController.java
@@ -326,6 +326,11 @@ public class SearchController extends BaseController {
         if (qfArray != null && qfArray.length != refinementArray.length) {
             refinementArray = qfArray;
         }
+        
+        // EA-3979 fix bug where + (instead of spaces) inside refinements breaks them
+        for (int i=0; i<refinementArray.length; i++) {
+            refinementArray[i] = refinementArray[i].replaceAll("\\+"," ");
+        }
 
         if (StringUtils.isNotBlank(theme)) {
             if (StringUtils.containsAny(theme, "+ #%^&*-='\"<>`!@[]{}\\/|")) {
@@ -1329,9 +1334,9 @@ public class SearchController extends BaseController {
         SolrClient solrClient = getSolrClient(requestRoute);
 
         if (profiles.contains(Profile.DEBUG)) {
-            resultSet = searchService.search(solrClient, clazz, query, true,isToDivideQueryRefinements);
+            resultSet = searchService.search(solrClient, clazz, query, true, isToDivideQueryRefinements);
         } else {
-            resultSet = searchService.search(solrClient, clazz, query,isToDivideQueryRefinements);
+            resultSet = searchService.search(solrClient, clazz, query, isToDivideQueryRefinements);
         }
         response.totalResults = resultSet.getResultSize();
         if (StringUtils.isNotBlank(resultSet.getCurrentCursorMark()) &&


### PR DESCRIPTION
Fixed a bug where URLencoded whitespaces (to "+") broke refinements with multiple elements, like `contentTier:(1+OR+2+OR+3+OR+4)`